### PR TITLE
Update Status page styling #21

### DIFF
--- a/pages/status/[page].js
+++ b/pages/status/[page].js
@@ -4,55 +4,60 @@ import Link from "next/link";
 import { useState } from "react";
 
 function StatusPage(props) {
-	const [isStatusTrue] = useState(true);
+	const [isStatusTrue] = useState(props.upCheckStatus);
 	const moment = require("moment");
 
 	return (
-		<div className="mt-20 max-w-7xl mx-auto h-screen">
-			<div className="flex flex-col lg:flex-row lg:items-center lg:gap-16 mx-auto px-4 md:px-12 lg:px-20">
-				<Image
-					className="w-full lg:w-1/2"
-					src={"data:image/gif;base64," + props.image}
-					width={400}
-					height={400}
-				/>
-				<ul className="text-stone-50 text-2xl flex flex-col gap-4 mt-16 lg:mt-0">
-					<li className="text-violet-400">
-						Site Name: <span className="text-white">{props.name}</span>
-					</li>
-					<hr />
-					<li className="text-violet-400">
-						<Link href={props.url}>
-							Site URL :{" "}
-							<span className="text-white hover:underline">{props.url}</span>{" "}
-						</Link>
-					</li>
-					<hr />
-					<li className="text-violet-400">
-						Last check time:{" "}
-						<span className="text-white">
-							{moment(props.lastCheck).format("MMMM Do YYYY, h:mm:ss a")}
-						</span>
-					</li>
-					<hr />
-
-					<li className="text-violet-400">
-						Status:{" "}
-						<span className={isStatusTrue ? "text-green-400" : "text-red-400"}>
-							{props.upCheckStatus.toString()}
-						</span>
-					</li>
-					<hr />
-					<li className="text-violet-400">
-						Accepted Status code:{" "}
-						<span className="text-white">{props.acceptedStatusCodes}</span>
-					</li>
-					<hr />
-					<li className="text-violet-400">
-						Port: <span className="text-white">{props.port}</span>
-					</li>
-					<hr />
-				</ul>
+		<div className="py-20 max-w-7xl mx-auto h-full lg:h-screen">
+			<div
+				class={` border-l-8 ${
+					isStatusTrue
+						? "bg-green-900/20 border-green-500"
+						: "bg-red-900/20 border-red-500"
+				} rounded p-4 mx-10`}
+				role="alert"
+			>
+				<div className="flex flex-col gap-16 justify-between box-border lg:flex-row lg:items-center lg:gap-16 mx-auto p-4">
+					<ul className="text-2xl flex flex-col gap-4 lg:mt-0">
+						<li className="text-slate-400">
+							Site Name: <span className="text-white">{props.name}</span>
+						</li>
+						<li className="text-slate-400">
+							<Link href={props.url}>
+								Site URL:{" "}
+								<span className="text-white hover:underline">{props.url}</span>{" "}
+							</Link>
+						</li>
+						<li className="text-slate-400">
+							Accepted Status code:{" "}
+							<span className="text-white">{props.acceptedStatusCodes}</span>
+						</li>
+						<li className="text-slate-400">
+							Port: <span className="text-white">{props.port}</span>
+						</li>
+						<li className="text-slate-400">
+							Status:{" "}
+							<span
+								className={isStatusTrue ? "text-green-400" : "text-red-400"}
+							>
+								{isStatusTrue.toString()}
+							</span>
+						</li>
+						<li className="text-slate-400">
+							Last check time:{" "}
+							<span className="text-white">
+								{moment(props.lastCheck).format("MMMM Do YYYY, h:mm:ss a")}
+							</span>
+						</li>
+					</ul>
+					<Image
+						className="w-full lg:w-1/3 rounded"
+						src={"data:image/gif;base64," + props.image}
+						width={400}
+						height={400}
+						alt={props.name}
+					/>
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Inspired from [Uptime](https://demo.upptime.js.org/), the Status page is updated. 
- Added the colored visualization, left bar & background, depending on the status - green for `ture`, red for `false`. 

### Before
<img width="1149" alt="Screen Shot 2023-01-30 at 18 00 49" src="https://user-images.githubusercontent.com/85666232/215409121-e3bd2020-7b37-42a2-8a0d-705362c8cf4b.png">

### After
![status_true_desktop](https://user-images.githubusercontent.com/85666232/215408788-4139b554-074d-4893-8b4e-0e272cf53e66.png)
![status_false_desktop](https://user-images.githubusercontent.com/85666232/215408806-100cadc2-cae5-45a9-b64b-114bb39ddb1e.png)
![status_true_mobile](https://user-images.githubusercontent.com/85666232/215408824-a5e4d0a1-7d2a-45c2-ab33-1df0acebd73d.png)![status_false_mobile](https://user-images.githubusercontent.com/85666232/215408841-9a70def3-969a-4b5d-8e11-36682013e556.png)